### PR TITLE
Update traefik example without external deps

### DIFF
--- a/traefik/README.md
+++ b/traefik/README.md
@@ -1,17 +1,17 @@
 # Pomerium as forward-auth provider for Traefik
 
+Run this demo locally on your docker-compose capable workstation, or replace `localhost.pomerium.io` with your own domain if running on a server.
+
 ## Includes
 
 - Authentication and Authorization managed by pomerium
-- Certificates managed by LetsEncrypt
 - Routing / reverse proxying handled by traefik
 
 ## How
 
-- Replace `x.y.z` with your domain in `config.yaml` and `docker-compose.yaml`.
-- Replace `you@x.y.z` with your email.
+- Update `config.yaml` for your e-mail address, if not using gmail/google.
 - Replace secrets in `config.yaml`.
 - Run `docker-compose up` from this directory.
-- Navigate to `https://httpbin.x.y.z`
+- Navigate to `https://httpbin.localhost.pomerium.io`
 - ???
 - Profit

--- a/traefik/config.yaml
+++ b/traefik/config.yaml
@@ -1,21 +1,21 @@
 # Main configuration flags : https://www.pomerium.io/docs/reference/reference/
 
 pomerium_debug: true
+address: :80
 cookie_secret: YVFTMIfW8yBJw+a6sYwdW8rHbU+IAAV/SUkCTg9Jtpo=
 shared_secret: 80ldlrU2d7w+wVpKNfevk6fmb8otEx6CqOfshj2LwhQ=
 
 idp_provider: "google"
-idp_client_id: ""
-idp_client_secret: "-"
-idp_service_account: ""
+idp_client_id: REPLACEME
+idp_client_secret: REPLACEME
 
 insecure_server: true
-forward_auth_url: https://fwdauth.x.y.z
-authenticate_service_url: https://authenticate.x.y.z
+forward_auth_url: http://pomerium
+authenticate_service_url: https://authenticate.localhost.pomerium.io
 
 policy:
-  - from: https://httpbin.x.y.z
-    to: http://httpbin.localhost
+  - from: https://httpbin.localhost.pomerium.io
+    to: https://httpbin
     allowed_domains:
       - pomerium.io
       - gmail.com

--- a/traefik/docker-compose.yaml
+++ b/traefik/docker-compose.yaml
@@ -5,9 +5,6 @@ services:
     command:
       - "--accesslog=true"
       - "--api.insecure=true"
-      - "--certificatesResolvers.leresolver.acme.email=you@x.y.z"
-      - "--certificatesResolvers.leresolver.acme.storage=/letsencrypt/acme.json"
-      - "--certificatesResolvers.leresolver.acme.tlschallenge=true"
       - "--entrypoints.web.address=:80"
       - "--entrypoints.websecure.address=:443"
       - "--entryPoints.websecure.forwardedHeaders.insecure"
@@ -20,27 +17,28 @@ services:
       - "8080:8080"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - $HOME/docker/letsencrypt:/letsencrypt
+
   httpbin:
     image: kennethreitz/httpbin:latest
     labels:
       - "traefik.http.middlewares.pomerium.forwardauth.authResponseHeaders=X-Pomerium-Authenticated-User-Email,x-pomerium-authenticated-user-id,x-pomerium-authenticated-user-groups,x-pomerium-jwt-assertion"
-      - "traefik.http.middlewares.pomerium.forwardauth.address=https://fwdauth.x.y.z/?uri=https://httpbin.x.y.z"
+      - "traefik.http.middlewares.pomerium.forwardauth.address=http://pomerium/?uri=https://httpbin.localhost.pomerium.io"
       - "traefik.http.middlewares.pomerium.forwardauth.trustForwardHeader=true"
 
       - "traefik.http.routers.httpbin.middlewares=pomerium@docker"
       - "traefik.enable=true"
-      - "traefik.http.routers.httpbin.rule=Host(`httpbin.x.y.z`)"
+      - "traefik.http.routers.httpbin.rule=Host(`httpbin.localhost.pomerium.io`)"
       - "traefik.http.routers.httpbin.entrypoints=websecure"
-      - "traefik.http.routers.httpbin.tls.certresolver=leresolver"
+      - "traefik.http.routers.httpbin.tls=true"
+
   pomerium:
     image: pomerium/pomerium:latest
     volumes:
       - ./config.yaml:/pomerium/config.yaml:ro
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.pomerium.rule=Host(`authenticate.x.y.z`,`fwdauth.x.y.z`)"
+      - "traefik.http.routers.pomerium.rule=Host(`authenticate.localhost.pomerium.io`)"
       - "traefik.http.routers.pomerium.entrypoints=websecure"
-      - "traefik.http.routers.pomerium.tls.certresolver=leresolver"
+      - "traefik.http.routers.pomerium.tls=true"
     expose:
-      - 443
+      - 80


### PR DESCRIPTION
- Use `*.localhost.pomerium.io` alias
- Lean on traefik's default TLS to run locally
- Use internal foward auth URL to simplify setup